### PR TITLE
Docs fixes and now checks all errors

### DIFF
--- a/keys/ed25519.go
+++ b/keys/ed25519.go
@@ -22,9 +22,10 @@ func encodeEd25519PublicKey(key []byte) (string, error) {
 	prefix := varint.ToUvarint(uint64(codec.X25519Pub))
 	bytes := append(prefix, key...)
 	// The spec specifies base58 btc...
-	// No error checking here, because we're using mbase consts directly.
-	str, _ := mbase.Encode(mbase.Base58BTC, bytes)
-	// Leaving possible error return gere in case we need it in the future
+	str, err := mbase.Encode(mbase.Base58BTC, bytes)
+	if err != nil {
+		return "", err
+	}
 	return str, nil
 }
 
@@ -32,14 +33,20 @@ func encodeEd25519PublicKey(key []byte) (string, error) {
 func ExpandEd25519Key(bytes []byte, fingerprint string) (*resolver.Document, error) {
 	did := fmt.Sprintf("did:key:%s", fingerprint)
 	keyID := fmt.Sprintf("%s#%s", did, fingerprint)
-	// No error checking here, because we're using mbase consts directly.
-	keyMultiBase, _ := mbase.Encode(mbase.Base58BTC, bytes)
+	keyMultiBase, err := mbase.Encode(mbase.Base58BTC, bytes)
+	if err != nil {
+		return nil, err
+	}
 	x25519Bytes := ed2curve25519.Ed25519PublicKeyToCurve25519(bytes)
-	// No error checking here, because we're using mbase consts directly.
-	x25519Encoded, _ := encodeEd25519PublicKey(x25519Bytes)
+	x25519Encoded, err := encodeEd25519PublicKey(x25519Bytes)
+	if err != nil {
+		return nil, err
+	}
 	x25519ID := fmt.Sprintf("%s#%s", did, x25519Encoded)
-	// No error checking here, because we're using mbase consts directly.
-	x25519MultiBase, _ := mbase.Encode(mbase.Base58BTC, x25519Bytes)
+	x25519MultiBase, err := mbase.Encode(mbase.Base58BTC, x25519Bytes)
+	if err != nil {
+		return nil, err
+	}
 	doc := &resolver.Document{
 		Context: []string{"https://w3id.org/did/v1"},
 		ID:      did,
@@ -60,6 +67,5 @@ func ExpandEd25519Key(bytes []byte, fingerprint string) (*resolver.Document, err
 			},
 		},
 	}
-	// Leaving possible error return gere in case we need it in the future
 	return doc, nil
 }

--- a/keys/keys_test.go
+++ b/keys/keys_test.go
@@ -41,12 +41,12 @@ func TestExpandEd25519Key(t *testing.T) {
 	var expected resolver.Document
 	err = json.Unmarshal(byteValue, &expected)
 	if err != nil {
-		t.Error(err)
+		t.Fatal(err)
 	}
 
 	observed, err := ExpandEd25519Key(publicKeyBytes, id)
 	if err != nil {
-		t.Error(err)
+		t.Fatal(err)
 	}
 
 	if !reflect.DeepEqual(observed, &expected) {
@@ -78,12 +78,12 @@ func TestExpandSecp256k1Key(t *testing.T) {
 	var expected resolver.Document
 	err = json.Unmarshal(byteValue, &expected)
 	if err != nil {
-		t.Error(err)
+		t.Fatal(err)
 	}
 
 	observed, err := ExpandSecp256k1Key(publicKeyBytes, id)
 	if err != nil {
-		t.Error(err)
+		t.Fatal(err)
 	}
 
 	if !reflect.DeepEqual(observed, &expected) {
@@ -93,17 +93,16 @@ func TestExpandSecp256k1Key(t *testing.T) {
 
 func TestEd25519KeyResolver(t *testing.T) {
 	id := "did:key:z6MktvqCyLxTsXUH1tUZncNdVeEZ7hNh7npPRbUU27GTrYb8"
-	// TODO: Carson's local random did:
 	// id := "did:key:z6Mkg9cRA65MvVbNdZCMpiqiFiWD8guY9oRGHeeC3J1qsCk5"
 
 	parsed, err := did.Parse(id)
 	if err != nil {
-		t.Error(err)
+		t.Fatal(err)
 	}
 	r := New()
 	observed, err := r.Resolve(id, parsed, r)
 	if err != nil {
-		t.Error(err)
+		t.Fatal(err)
 	}
 	byteValue, err := ioutil.ReadFile("testdata/ed25519.json")
 	if err != nil {
@@ -112,7 +111,7 @@ func TestEd25519KeyResolver(t *testing.T) {
 	var expected resolver.Document
 	err = json.Unmarshal(byteValue, &expected)
 	if err != nil {
-		t.Error(err)
+		t.Fatal(err)
 	}
 
 	if !reflect.DeepEqual(observed, &expected) {
@@ -125,12 +124,12 @@ func TestSecp256k1KeyResolver(t *testing.T) {
 
 	parsed, err := did.Parse(id)
 	if err != nil {
-		t.Error(err)
+		t.Fatal(err)
 	}
 	r := New()
 	observed, err := r.Resolve(id, parsed, r)
 	if err != nil {
-		t.Error(err)
+		t.Fatal(err)
 	}
 	byteValue, err := ioutil.ReadFile("testdata/secp256k1.json")
 	if err != nil {
@@ -139,7 +138,7 @@ func TestSecp256k1KeyResolver(t *testing.T) {
 	var expected resolver.Document
 	err = json.Unmarshal(byteValue, &expected)
 	if err != nil {
-		t.Error(err)
+		t.Fatal(err)
 	}
 
 	if !reflect.DeepEqual(observed, &expected) {
@@ -152,7 +151,7 @@ func TestUnknownMethod(t *testing.T) {
 
 	parsed, err := did.Parse(id)
 	if err != nil {
-		t.Error(err)
+		t.Fatal(err)
 	}
 	r := New()
 	_, err = r.Resolve(id, parsed, r)
@@ -199,7 +198,6 @@ func TestInvalidMultibase(t *testing.T) {
 	}
 	r := New()
 	_, err = r.Resolve(id, parsed, r)
-	// We don't support "x25519-pub" keys directly
 	if err == nil || err.Error() != "selected encoding not supported" {
 		t.Error("expected Resolve to return error")
 	}
@@ -214,7 +212,6 @@ func TestInvalidVarint(t *testing.T) {
 	}
 	r := New()
 	_, err = r.Resolve(id, parsed, r)
-	// We don't support "x25519-pub" keys directly
 	if err == nil || err.Error() != "varints larger than uint63 not supported" {
 		t.Error("expected Resolve to return error")
 	}

--- a/keys/secp256k1.go
+++ b/keys/secp256k1.go
@@ -15,8 +15,10 @@ import (
 func ExpandSecp256k1Key(bytes []byte, fingerprint string) (*resolver.Document, error) {
 	did := fmt.Sprintf("did:key:%s", fingerprint)
 	keyID := fmt.Sprintf("%s#%s", did, fingerprint)
-	// No error checking here, because we're using mbase consts directly.
-	keyMultiBase, _ := mbase.Encode(mbase.Base16, bytes)
+	keyMultiBase, err := mbase.Encode(mbase.Base16, bytes)
+	if err != nil {
+		return nil, err
+	}
 	doc := &resolver.Document{
 		Context: []string{"https://w3id.org/did/v1"},
 		ID:      did,
@@ -29,6 +31,5 @@ func ExpandSecp256k1Key(bytes []byte, fingerprint string) (*resolver.Document, e
 			},
 		},
 	}
-	// Leaving possible error return gere in case we need it in the future
 	return doc, nil
 }

--- a/resolver/resolver.go
+++ b/resolver/resolver.go
@@ -13,7 +13,7 @@ import (
 
 // Document is a did document that describes a did subject.
 // See https://www.w3.org/TR/did-core/#dfn-did-documents.
-// We include some non-standard keys here for compatability reasons
+// TODO: Should we include the non-standard publicKey field for compatability reasons?
 // See https://w3c.github.io/did-spec-registries/#publickey
 type Document struct {
 	Context            []string             `json:"@context"` // https://w3id.org/did/v1
@@ -60,11 +60,11 @@ type ResolutionOptions struct {
 
 // ResolutionMetadata defined a metadata structure consisting of values relating to the results of the did resolution process.
 // See https://w3c.github.io/did-core/#did-resolution-metadata
-// See https://w3c.github.io/did-spec-registries/#did-resolution-metadata
+// See https://w3c.github.io/did-spec-registries/#did-resolution-metadata (possibly outdated)
 // ContentType indicates the media type of the returned did document stream.
 // This property must not be present if the resolve function was called.
 // The error code from the resolution process. This property is required when there is an error in the resolution process.
-// Curret possible values include: "invalid-did", "invalid-did-url", "not-found", "deactivated", "unsupported-did-method", "representation-not-supported"
+// Current common error values include: "invalidDid", "notFound", "representationNotSupported"
 type ResolutionMetadata struct {
 	ContentType string `json:"content-type,omitempty"`
 	Error       string `json:"error,omitempty"`
@@ -157,7 +157,7 @@ func (r Registry) Parse(did string) (*parse.DID, error) {
 func (r Registry) Resolve(did string, resolutionOptions *ResolutionOptions) (ResolutionMetadata, *Document, DocumentMetadata, error) {
 	parsed, err := r.Parse(did)
 	if err != nil {
-		return ResolutionMetadata{Error: "invalid-did-url"}, nil, DocumentMetadata{}, err
+		return ResolutionMetadata{Error: "invalidDid"}, nil, DocumentMetadata{}, err
 	}
 	resolver, ok := r.registry[parsed.Method]
 	var doc *Document
@@ -170,12 +170,12 @@ func (r Registry) Resolve(did string, resolutionOptions *ResolutionOptions) (Res
 			doc, err = resolver.Resolve(parsed.String(), parsed, resolver)
 		}
 		if err != nil {
-			return ResolutionMetadata{Error: "invalid-did"}, nil, DocumentMetadata{}, err
+			return ResolutionMetadata{Error: "invalidDid"}, nil, DocumentMetadata{}, err
 		}
 		if doc == nil {
-			return ResolutionMetadata{Error: "not-found"}, nil, DocumentMetadata{}, fmt.Errorf("resolver returned nil for: '%s'", parsed.String())
+			return ResolutionMetadata{Error: "notFound"}, nil, DocumentMetadata{}, fmt.Errorf("resolver returned nil for: '%s'", parsed.String())
 		}
 		return ResolutionMetadata{}, doc, DocumentMetadata{}, nil
 	}
-	return ResolutionMetadata{Error: "invalid-did-url"}, nil, DocumentMetadata{}, fmt.Errorf("unknown did method: '%s'", parsed.Method)
+	return ResolutionMetadata{Error: "notFound"}, nil, DocumentMetadata{}, fmt.Errorf("unknown did method: '%s'", parsed.Method)
 }

--- a/threeid/docid.go
+++ b/threeid/docid.go
@@ -96,7 +96,10 @@ func (doc *DocID) Bytes() []byte {
 
 func (doc *DocID) String() string {
 	bytes := doc.Bytes()
-	encoded, _ := mbase.Encode(mbase.Base36, bytes)
+	encoded, err := mbase.Encode(mbase.Base36, bytes)
+	if err != nil {
+		return ""
+	}
 	return encoded
 }
 
@@ -133,7 +136,10 @@ func (doc *CommitID) Bytes() []byte {
 
 func (doc *CommitID) String() string {
 	bytes := doc.Bytes()
-	encoded, _ := mbase.Encode(mbase.Base36, bytes)
+	encoded, err := mbase.Encode(mbase.Base36, bytes)
+	if err != nil {
+		return ""
+	}
 	return encoded
 }
 

--- a/threeid/threeid.go
+++ b/threeid/threeid.go
@@ -93,7 +93,10 @@ func resolve(client Client, id string, commit cid.Cid) (*resolver.Document, erro
 		if n != 2 {
 			return nil, fmt.Errorf("error parsing varint")
 		}
-		publicKeyBase58, _ := multibase.Encode(multibase.Base58BTC, keyBuf[2:])
+		publicKeyBase58, err := multibase.Encode(multibase.Base58BTC, keyBuf[2:])
+		if err != nil {
+			return nil, err
+		}
 		keyID := fmt.Sprintf("%s#%s", did, keyName)
 		switch keyType {
 		case uint64(codec.Secp256k1Pub):
@@ -139,13 +142,5 @@ func getVersion(query string) string {
 	}
 	return ""
 }
-
-// func wrapDocument(doc *resolver.Document, did string) (*resolver.Document, error) {
-// 	// Ceramic uses publicKeys
-// 	// See https://w3c.github.io/did-spec-registries/#publickey
-// 	if (content.)
-// 	return nil, nil
-
-// }
 
 var _ resolver.Resolver = (*Resolver)(nil)


### PR DESCRIPTION
This cleans up some tests, now checks all errors, even those that aren't likely to occur. This also improves some of the interfaces/structs for the did Documents to match existing specs more closely. It also adds some optional fields, and updates error types to reflect a more recent version of the did-core document.