### PR TITLE
Implements did:web resolver.

### DIFF
--- a/keys/ed25519.go
+++ b/keys/ed25519.go
@@ -22,9 +22,10 @@ func encodeEd25519PublicKey(key []byte) (string, error) {
 	prefix := varint.ToUvarint(uint64(codec.X25519Pub))
 	bytes := append(prefix, key...)
 	// The spec specifies base58 btc...
-	// No error checking here, because we're using mbase consts directly.
-	str, _ := mbase.Encode(mbase.Base58BTC, bytes)
-	// Leaving possible error return gere in case we need it in the future
+	str, err := mbase.Encode(mbase.Base58BTC, bytes)
+	if err != nil {
+		return "", err
+	}
 	return str, nil
 }
 
@@ -32,14 +33,20 @@ func encodeEd25519PublicKey(key []byte) (string, error) {
 func ExpandEd25519Key(bytes []byte, fingerprint string) (*resolver.Document, error) {
 	did := fmt.Sprintf("did:key:%s", fingerprint)
 	keyID := fmt.Sprintf("%s#%s", did, fingerprint)
-	// No error checking here, because we're using mbase consts directly.
-	keyMultiBase, _ := mbase.Encode(mbase.Base58BTC, bytes)
+	keyMultiBase, err := mbase.Encode(mbase.Base58BTC, bytes)
+	if err != nil {
+		return nil, err
+	}
 	x25519Bytes := ed2curve25519.Ed25519PublicKeyToCurve25519(bytes)
-	// No error checking here, because we're using mbase consts directly.
-	x25519Encoded, _ := encodeEd25519PublicKey(x25519Bytes)
+	x25519Encoded, err := encodeEd25519PublicKey(x25519Bytes)
+	if err != nil {
+		return nil, err
+	}
 	x25519ID := fmt.Sprintf("%s#%s", did, x25519Encoded)
-	// No error checking here, because we're using mbase consts directly.
-	x25519MultiBase, _ := mbase.Encode(mbase.Base58BTC, x25519Bytes)
+	x25519MultiBase, err := mbase.Encode(mbase.Base58BTC, x25519Bytes)
+	if err != nil {
+		return nil, err
+	}
 	doc := &resolver.Document{
 		Context: []string{"https://w3id.org/did/v1"},
 		ID:      did,
@@ -60,6 +67,5 @@ func ExpandEd25519Key(bytes []byte, fingerprint string) (*resolver.Document, err
 			},
 		},
 	}
-	// Leaving possible error return gere in case we need it in the future
 	return doc, nil
 }

--- a/keys/keys_test.go
+++ b/keys/keys_test.go
@@ -41,12 +41,12 @@ func TestExpandEd25519Key(t *testing.T) {
 	var expected resolver.Document
 	err = json.Unmarshal(byteValue, &expected)
 	if err != nil {
-		t.Error(err)
+		t.Fatal(err)
 	}
 
 	observed, err := ExpandEd25519Key(publicKeyBytes, id)
 	if err != nil {
-		t.Error(err)
+		t.Fatal(err)
 	}
 
 	if !reflect.DeepEqual(observed, &expected) {
@@ -78,12 +78,12 @@ func TestExpandSecp256k1Key(t *testing.T) {
 	var expected resolver.Document
 	err = json.Unmarshal(byteValue, &expected)
 	if err != nil {
-		t.Error(err)
+		t.Fatal(err)
 	}
 
 	observed, err := ExpandSecp256k1Key(publicKeyBytes, id)
 	if err != nil {
-		t.Error(err)
+		t.Fatal(err)
 	}
 
 	if !reflect.DeepEqual(observed, &expected) {
@@ -93,17 +93,16 @@ func TestExpandSecp256k1Key(t *testing.T) {
 
 func TestEd25519KeyResolver(t *testing.T) {
 	id := "did:key:z6MktvqCyLxTsXUH1tUZncNdVeEZ7hNh7npPRbUU27GTrYb8"
-	// TODO: Carson's local random did:
 	// id := "did:key:z6Mkg9cRA65MvVbNdZCMpiqiFiWD8guY9oRGHeeC3J1qsCk5"
 
 	parsed, err := did.Parse(id)
 	if err != nil {
-		t.Error(err)
+		t.Fatal(err)
 	}
 	r := New()
 	observed, err := r.Resolve(id, parsed, r)
 	if err != nil {
-		t.Error(err)
+		t.Fatal(err)
 	}
 	byteValue, err := ioutil.ReadFile("testdata/ed25519.json")
 	if err != nil {
@@ -112,7 +111,7 @@ func TestEd25519KeyResolver(t *testing.T) {
 	var expected resolver.Document
 	err = json.Unmarshal(byteValue, &expected)
 	if err != nil {
-		t.Error(err)
+		t.Fatal(err)
 	}
 
 	if !reflect.DeepEqual(observed, &expected) {
@@ -125,12 +124,12 @@ func TestSecp256k1KeyResolver(t *testing.T) {
 
 	parsed, err := did.Parse(id)
 	if err != nil {
-		t.Error(err)
+		t.Fatal(err)
 	}
 	r := New()
 	observed, err := r.Resolve(id, parsed, r)
 	if err != nil {
-		t.Error(err)
+		t.Fatal(err)
 	}
 	byteValue, err := ioutil.ReadFile("testdata/secp256k1.json")
 	if err != nil {
@@ -139,7 +138,7 @@ func TestSecp256k1KeyResolver(t *testing.T) {
 	var expected resolver.Document
 	err = json.Unmarshal(byteValue, &expected)
 	if err != nil {
-		t.Error(err)
+		t.Fatal(err)
 	}
 
 	if !reflect.DeepEqual(observed, &expected) {
@@ -152,7 +151,7 @@ func TestUnknownMethod(t *testing.T) {
 
 	parsed, err := did.Parse(id)
 	if err != nil {
-		t.Error(err)
+		t.Fatal(err)
 	}
 	r := New()
 	_, err = r.Resolve(id, parsed, r)
@@ -199,7 +198,6 @@ func TestInvalidMultibase(t *testing.T) {
 	}
 	r := New()
 	_, err = r.Resolve(id, parsed, r)
-	// We don't support "x25519-pub" keys directly
 	if err == nil || err.Error() != "selected encoding not supported" {
 		t.Error("expected Resolve to return error")
 	}
@@ -214,7 +212,6 @@ func TestInvalidVarint(t *testing.T) {
 	}
 	r := New()
 	_, err = r.Resolve(id, parsed, r)
-	// We don't support "x25519-pub" keys directly
 	if err == nil || err.Error() != "varints larger than uint63 not supported" {
 		t.Error("expected Resolve to return error")
 	}

--- a/keys/secp256k1.go
+++ b/keys/secp256k1.go
@@ -15,8 +15,10 @@ import (
 func ExpandSecp256k1Key(bytes []byte, fingerprint string) (*resolver.Document, error) {
 	did := fmt.Sprintf("did:key:%s", fingerprint)
 	keyID := fmt.Sprintf("%s#%s", did, fingerprint)
-	// No error checking here, because we're using mbase consts directly.
-	keyMultiBase, _ := mbase.Encode(mbase.Base16, bytes)
+	keyMultiBase, err := mbase.Encode(mbase.Base16, bytes)
+	if err != nil {
+		return nil, err
+	}
 	doc := &resolver.Document{
 		Context: []string{"https://w3id.org/did/v1"},
 		ID:      did,
@@ -29,6 +31,5 @@ func ExpandSecp256k1Key(bytes []byte, fingerprint string) (*resolver.Document, e
 			},
 		},
 	}
-	// Leaving possible error return gere in case we need it in the future
 	return doc, nil
 }

--- a/resolver/resolver.go
+++ b/resolver/resolver.go
@@ -13,7 +13,7 @@ import (
 
 // Document is a did document that describes a did subject.
 // See https://www.w3.org/TR/did-core/#dfn-did-documents.
-// We include some non-standard keys here for compatability reasons
+// TODO: Should we include the non-standard publicKey field for compatability reasons?
 // See https://w3c.github.io/did-spec-registries/#publickey
 type Document struct {
 	Context            []string             `json:"@context"` // https://w3id.org/did/v1
@@ -60,11 +60,11 @@ type ResolutionOptions struct {
 
 // ResolutionMetadata defined a metadata structure consisting of values relating to the results of the did resolution process.
 // See https://w3c.github.io/did-core/#did-resolution-metadata
-// See https://w3c.github.io/did-spec-registries/#did-resolution-metadata
+// See https://w3c.github.io/did-spec-registries/#did-resolution-metadata (possibly outdated)
 // ContentType indicates the media type of the returned did document stream.
 // This property must not be present if the resolve function was called.
 // The error code from the resolution process. This property is required when there is an error in the resolution process.
-// Curret possible values include: "invalid-did", "invalid-did-url", "not-found", "deactivated", "unsupported-did-method", "representation-not-supported"
+// Current common error values include: "invalidDid", "notFound", "representationNotSupported"
 type ResolutionMetadata struct {
 	ContentType string `json:"content-type,omitempty"`
 	Error       string `json:"error,omitempty"`
@@ -157,7 +157,7 @@ func (r Registry) Parse(did string) (*parse.DID, error) {
 func (r Registry) Resolve(did string, resolutionOptions *ResolutionOptions) (ResolutionMetadata, *Document, DocumentMetadata, error) {
 	parsed, err := r.Parse(did)
 	if err != nil {
-		return ResolutionMetadata{Error: "invalid-did-url"}, nil, DocumentMetadata{}, err
+		return ResolutionMetadata{Error: "invalidDid"}, nil, DocumentMetadata{}, err
 	}
 	resolver, ok := r.registry[parsed.Method]
 	var doc *Document
@@ -170,12 +170,12 @@ func (r Registry) Resolve(did string, resolutionOptions *ResolutionOptions) (Res
 			doc, err = resolver.Resolve(parsed.String(), parsed, resolver)
 		}
 		if err != nil {
-			return ResolutionMetadata{Error: "invalid-did"}, nil, DocumentMetadata{}, err
+			return ResolutionMetadata{Error: "invalidDid"}, nil, DocumentMetadata{}, err
 		}
 		if doc == nil {
-			return ResolutionMetadata{Error: "not-found"}, nil, DocumentMetadata{}, fmt.Errorf("resolver returned nil for: '%s'", parsed.String())
+			return ResolutionMetadata{Error: "notFound"}, nil, DocumentMetadata{}, fmt.Errorf("resolver returned nil for: '%s'", parsed.String())
 		}
 		return ResolutionMetadata{}, doc, DocumentMetadata{}, nil
 	}
-	return ResolutionMetadata{Error: "invalid-did-url"}, nil, DocumentMetadata{}, fmt.Errorf("unknown did method: '%s'", parsed.Method)
+	return ResolutionMetadata{Error: "notFound"}, nil, DocumentMetadata{}, fmt.Errorf("unknown did method: '%s'", parsed.Method)
 }

--- a/threeid/docid.go
+++ b/threeid/docid.go
@@ -96,7 +96,10 @@ func (doc *DocID) Bytes() []byte {
 
 func (doc *DocID) String() string {
 	bytes := doc.Bytes()
-	encoded, _ := mbase.Encode(mbase.Base36, bytes)
+	encoded, err := mbase.Encode(mbase.Base36, bytes)
+	if err != nil {
+		return ""
+	}
 	return encoded
 }
 
@@ -133,7 +136,10 @@ func (doc *CommitID) Bytes() []byte {
 
 func (doc *CommitID) String() string {
 	bytes := doc.Bytes()
-	encoded, _ := mbase.Encode(mbase.Base36, bytes)
+	encoded, err := mbase.Encode(mbase.Base36, bytes)
+	if err != nil {
+		return ""
+	}
 	return encoded
 }
 

--- a/threeid/threeid.go
+++ b/threeid/threeid.go
@@ -93,7 +93,10 @@ func resolve(client Client, id string, commit cid.Cid) (*resolver.Document, erro
 		if n != 2 {
 			return nil, fmt.Errorf("error parsing varint")
 		}
-		publicKeyBase58, _ := multibase.Encode(multibase.Base58BTC, keyBuf[2:])
+		publicKeyBase58, err := multibase.Encode(multibase.Base58BTC, keyBuf[2:])
+		if err != nil {
+			return nil, err
+		}
 		keyID := fmt.Sprintf("%s#%s", did, keyName)
 		switch keyType {
 		case uint64(codec.Secp256k1Pub):
@@ -139,13 +142,5 @@ func getVersion(query string) string {
 	}
 	return ""
 }
-
-// func wrapDocument(doc *resolver.Document, did string) (*resolver.Document, error) {
-// 	// Ceramic uses publicKeys
-// 	// See https://w3c.github.io/did-spec-registries/#publickey
-// 	if (content.)
-// 	return nil, nil
-
-// }
 
 var _ resolver.Resolver = (*Resolver)(nil)

--- a/web/web.go
+++ b/web/web.go
@@ -1,0 +1,88 @@
+// Package web provides tools for resolving dids formed by taking an http(s)
+// domain and producing a well-known URI to access the did document.
+// See https://tools.ietf.org/html/rfc5785 for details.
+// Copyright 2021 Textile
+// Copyright 2021 Decentralized Identity Foundation
+package web
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"strings"
+
+	"github.com/ockam-network/did"
+	"github.com/textileio/go-did-resolver/resolver"
+)
+
+// DocPath is the default path at which to look for the did.json document
+const DocPath = "/.well-known/did.json"
+
+// Getter is a simple interface for Getting an *http.Response.
+type Getter interface {
+	Get(url string) (resp *http.Response, err error)
+}
+
+// Client is the default client used to Get *http.Responses.
+var Client Getter
+
+// The init function sets the Client var to instance of http.Client.
+// https://www.thegreatcodeadventure.com/mocking-http-requests-in-golang/
+func init() {
+	Client = &http.Client{}
+}
+
+// Resolver takes an http(s) domain and resolves a well-known URI-based did
+// document.
+type Resolver struct{}
+
+// New creates and returns a new Resolver.
+func New() *Resolver {
+	return &Resolver{}
+}
+
+// Method returns the method that this resolver is capable of resolving.
+func (r *Resolver) Method() string {
+	return "web"
+}
+
+// Resolve is the primary resolution method for this resolver.
+// For a did did:web:example.com, the resolver will attempt to access the
+// document at https://example.com/.well-known/did.json
+func (r *Resolver) Resolve(did string, parsed *did.DID, res resolver.Resolver) (*resolver.Document, error) {
+	if parsed.Method != r.Method() {
+		return nil, fmt.Errorf("unknown did method: '%s'", parsed.Method)
+	}
+	path := parsed.ID + DocPath
+	id := strings.Split(parsed.ID, ":")
+	if len(id) > 1 {
+		path = strings.Join(id, "/") + "/did.json"
+	}
+	url := "https://" + path
+	resp, err := Client.Get(url)
+	if err != nil {
+		return nil, err
+	}
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("unable to resolve: '%s'", resp.Status)
+	}
+	if resp.Body == nil {
+		return nil, fmt.Errorf("empty did document")
+	}
+	defer resp.Body.Close()
+
+	var state resolver.Document
+	err = json.NewDecoder(resp.Body).Decode(&state)
+	if err != nil {
+		return nil, err
+	}
+	if state.ID != did {
+		return nil, fmt.Errorf("id does not match requested did")
+	}
+	if len(state.VerificationMethod) < 1 {
+		return nil, fmt.Errorf("no verification methods")
+	}
+	return &state, nil
+}
+
+var _ resolver.Resolver = (*Resolver)(nil)

--- a/web/web_test.go
+++ b/web/web_test.go
@@ -1,0 +1,295 @@
+package web
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io/ioutil"
+	"net/http"
+	"reflect"
+	"strings"
+	"testing"
+
+	"github.com/ockam-network/did"
+	"github.com/textileio/go-did-resolver/resolver"
+)
+
+func init() {
+	Client = &MockClient{}
+}
+
+var (
+	// GetFunc fetches the mock client's `Get` func
+	GetFunc func(url string) (*http.Response, error)
+	// Key is a randomly generated Secp256k1VerificationKey2018
+	Key = "f02d41c913f542ae671e6df17a456c7dd6a280479d491120629daf92130602cd135"
+)
+
+// MockClient is the mock client
+type MockClient struct {
+	Getter
+}
+
+// Get is the mock client's `Get` func
+func (m *MockClient) Get(url string) (*http.Response, error) {
+	return GetFunc(url)
+}
+
+func TestUnknownMethod(t *testing.T) {
+	id := "did:borg:example.com"
+
+	parsed, err := did.Parse(id)
+	if err != nil {
+		t.Fatal(err)
+	}
+	r := New()
+	_, err = r.Resolve(id, parsed, r)
+	if err == nil || err.Error() != "unknown did method: 'borg'" {
+		t.Error("expected Resolve to return error")
+	}
+}
+
+func TestFailOnGet(t *testing.T) {
+	id := "did:web:example.com"
+
+	parsed, err := did.Parse(id)
+	if err != nil {
+		t.Fatal(err)
+	}
+	// Mock the Get function for our test
+	GetFunc = func(url string) (*http.Response, error) {
+		return &http.Response{
+			StatusCode: 404,
+		}, fmt.Errorf("expected error")
+	}
+	r := New()
+	_, err = r.Resolve(id, parsed, r)
+	if err == nil || err.Error() != "expected error" {
+		t.Error("expected Resolve to return error")
+	}
+}
+
+func TestResolveDocument(t *testing.T) {
+	id := "did:web:example.com"
+	expected := &resolver.Document{
+		Context: []string{"https://w3id.org/did/v1"},
+		ID:      id,
+		VerificationMethod: []resolver.VerificationMethod{
+			{
+				ID:                 fmt.Sprintf("%s#owner", id),
+				Type:               "Secp256k1VerificationKey2018",
+				Controller:         id,
+				PublicKeyMultibase: Key,
+			},
+		},
+		Authentication: []resolver.VerificationMethod{
+			{
+				Type:      "Secp256k1SignatureAuthentication2018",
+				PublicKey: fmt.Sprintf("%s#owner", id),
+			},
+		},
+	}
+	parsed, err := did.Parse(id)
+	if err != nil {
+		t.Fatal(err)
+	}
+	res := New()
+	data, err := json.Marshal(expected)
+	if err != nil {
+		t.Fatal(err)
+	}
+	// Mock the Get function for our test
+	GetFunc = func(url string) (*http.Response, error) {
+		return &http.Response{
+			StatusCode: 200,
+			Body:       ioutil.NopCloser(bytes.NewReader(data)),
+		}, nil
+	}
+	observed, err := res.Resolve(id, parsed, res)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !reflect.DeepEqual(observed, expected) {
+		t.Errorf("expected document to match: %s", observed.ID)
+	}
+}
+
+func TestResolveLongDid(t *testing.T) {
+	id := "did:web:example.com:user:alice"
+	expected := &resolver.Document{
+		Context: []string{"https://w3id.org/did/v1"},
+		ID:      id,
+		VerificationMethod: []resolver.VerificationMethod{
+			{
+				ID:                 fmt.Sprintf("%s#owner", id),
+				Type:               "Secp256k1VerificationKey2018",
+				Controller:         id,
+				PublicKeyMultibase: Key,
+			},
+		},
+		Authentication: []resolver.VerificationMethod{
+			{
+				Type:      "Secp256k1SignatureAuthentication2018",
+				PublicKey: fmt.Sprintf("%s#owner", id),
+			},
+		},
+	}
+	parsed, err := did.Parse(id)
+	if err != nil {
+		t.Fatal(err)
+	}
+	res := New()
+	data, err := json.Marshal(expected)
+	if err != nil {
+		t.Fatal(err)
+	}
+	// Mock the Get function for our test
+	GetFunc = func(url string) (*http.Response, error) {
+		return &http.Response{
+			StatusCode: 200,
+			Body:       ioutil.NopCloser(bytes.NewReader(data)),
+		}, nil
+	}
+	observed, err := res.Resolve(id, parsed, res)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !reflect.DeepEqual(observed, expected) {
+		t.Errorf("expected document to match: %s", observed.ID)
+	}
+}
+
+func TestFailOnStatus(t *testing.T) {
+	id := "did:web:example.com"
+	parsed, err := did.Parse(id)
+	if err != nil {
+		t.Fatal(err)
+	}
+	res := New()
+	// Mock the Get function for our test
+	GetFunc = func(url string) (*http.Response, error) {
+		return &http.Response{
+			StatusCode: 404,
+			Status:     "Not Found",
+		}, nil
+	}
+	_, err = res.Resolve(id, parsed, res)
+	if err == nil || err.Error() != "unable to resolve: 'Not Found'" {
+		t.Error("expected Resolve to return error")
+	}
+}
+
+func TestFailOnBadResponse(t *testing.T) {
+	id := "did:web:example.com"
+	parsed, err := did.Parse(id)
+	if err != nil {
+		t.Fatal(err)
+	}
+	res := New()
+	// Mock the Get function for our test
+	GetFunc = func(url string) (*http.Response, error) {
+		return &http.Response{
+			StatusCode: 200,
+			Body:       ioutil.NopCloser(bytes.NewReader([]byte("bad json"))),
+		}, nil
+	}
+	_, err = res.Resolve(id, parsed, res)
+	if err == nil || !strings.Contains(err.Error(), "invalid character") {
+		t.Error("expected Resolve to return error")
+	}
+}
+
+func TestFailOnEmptyResponse(t *testing.T) {
+	id := "did:web:example.com"
+	parsed, err := did.Parse(id)
+	if err != nil {
+		t.Fatal(err)
+	}
+	res := New()
+	// Mock the Get function for our test
+	GetFunc = func(url string) (*http.Response, error) {
+		return &http.Response{
+			StatusCode: 200,
+		}, nil
+	}
+	_, err = res.Resolve(id, parsed, res)
+	if err == nil || err.Error() != "empty did document" {
+		t.Error("expected Resolve to return error")
+	}
+}
+
+func TestFailOnMismatch(t *testing.T) {
+	id := "did:web:example.com"
+	wrong := &resolver.Document{
+		Context: []string{"https://w3id.org/did/v1"},
+		ID:      "did:web:wrong.com",
+		VerificationMethod: []resolver.VerificationMethod{
+			{
+				ID:                 fmt.Sprintf("%s#owner", id),
+				Type:               "Secp256k1VerificationKey2018",
+				Controller:         id,
+				PublicKeyMultibase: Key,
+			},
+		},
+		Authentication: []resolver.VerificationMethod{
+			{
+				Type:      "Secp256k1SignatureAuthentication2018",
+				PublicKey: fmt.Sprintf("%s#owner", id),
+			},
+		},
+	}
+	parsed, err := did.Parse(id)
+	if err != nil {
+		t.Fatal(err)
+	}
+	res := New()
+	data, err := json.Marshal(wrong)
+	if err != nil {
+		t.Fatal(err)
+	}
+	// Mock the Get function for our test
+	GetFunc = func(url string) (*http.Response, error) {
+		return &http.Response{
+			StatusCode: 200,
+			Body:       ioutil.NopCloser(bytes.NewReader(data)),
+		}, nil
+	}
+	_, err = res.Resolve(id, parsed, res)
+	if err == nil || err.Error() != "id does not match requested did" {
+		t.Error("expected Resolve to return error")
+	}
+}
+
+func TestFailNoVerificationMethods(t *testing.T) {
+	id := "did:web:example.com"
+	wrong := &resolver.Document{
+		Context: []string{"https://w3id.org/did/v1"},
+		ID:      id,
+		Authentication: []resolver.VerificationMethod{
+			{
+				Type:      "Secp256k1SignatureAuthentication2018",
+				PublicKey: fmt.Sprintf("%s#owner", id),
+			},
+		},
+	}
+	parsed, err := did.Parse(id)
+	if err != nil {
+		t.Fatal(err)
+	}
+	res := New()
+	data, err := json.Marshal(wrong)
+	if err != nil {
+		t.Fatal(err)
+	}
+	// Mock the Get function for our test
+	GetFunc = func(url string) (*http.Response, error) {
+		return &http.Response{
+			StatusCode: 200,
+			Body:       ioutil.NopCloser(bytes.NewReader(data)),
+		}, nil
+	}
+	_, err = res.Resolve(id, parsed, res)
+	if err == nil || err.Error() != "no verification methods" {
+		t.Error("expected Resolve to return error")
+	}
+}


### PR DESCRIPTION
This was a simple/quick one to help get my Go chops going. Finished up the tests so figured I might as well push it up and get it in and available. The swappable HTTP Client pattern used here comes from a run tutorial, it was quite helpful in exploring mocking of HTTP-based tests. Also makes it easier to plug in custom clients if that is required in the future.